### PR TITLE
Add http server functions

### DIFF
--- a/src/Http.elm
+++ b/src/Http.elm
@@ -1,11 +1,13 @@
 module Http
-  ( Error(..), get
+  ( Error(..), get, serve, getURL, responseEnd
   ) where
 
 {-|
 
 @docs Error
-@docs get
+@docs Request
+@docs Response
+@docs get, serve, getURL, sendResponse
 
 -}
 
@@ -18,8 +20,39 @@ import Native.Http
 type Error = NetworkError String
 
 
+{-| Request
+-}
+type Request = Request
+
+
+{-| Response
+-}
+type Response = Response
+
+
 {-| get
 -}
 get : String -> Task Error String
 get url =
   Native.Http.get url
+
+
+{-| serve
+-}
+serve : Int -> (Request -> Response -> Task x a) -> Task x () 
+serve prt taskFunction = 
+  Native.Http.serve prt taskFunction
+
+
+{-| getURL
+-}
+getURL : Request -> String
+getURL =
+  Native.Http.get_url
+
+
+{-| sendResponse
+-}
+sendResponse : Response -> String -> Task x ()
+sendResponse response s =
+  Task.succeed <| Native.Http.response_end response s

--- a/src/Http.elm
+++ b/src/Http.elm
@@ -1,5 +1,5 @@
 module Http
-  ( Error(..), get, serve, getURL, responseEnd
+  ( Error(..), get, serve, getURL, sendResponse
   ) where
 
 {-|

--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -31,8 +31,29 @@ Elm.Native.Http.make = function(localRuntime) {
 		});
 	}
 
+	function serve(port, task_function) {
+		return Task.asyncFunction(function(callback) {
+			http.createServer(function(request, response) { 
+				Task.perform(task_function(request)(response));
+			}).listen(port);
+			return callback(Task.succeed(Utils.Tuple0));
+		});
+	}
+
+	function get_url(request) {
+		return request.url;
+	}
+
+	function response_end(response, s) {
+		response.end(s);
+		return Utils.Tuple0;
+	}
+
 	return localRuntime.Native.Http.values = {
 		get: get,
+		serve: F2(serve),
+		get_url: get_url,
+		response_end: F2(response_end),
 	};
 };
 


### PR DESCRIPTION
Adds the ability to serve responses based on incoming HTTP requests. This can be used to create a persistent process in `elm-oracle` that responds much more quickly than the overhead of spinning up a new process on each query.
